### PR TITLE
Add ability to temporarily whitelist the currently selected app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,22 @@ I synchronize the text field with a real vim buffer.
 
 You can use all modes (even commandline etc.) and all commands included in vim.
 
+## svimrc
 It is also possible to load a custom `svimrc` file, which can contain
 custom vim configurations, e.g. remappings (see the examples folder).
 
+## Blacklist Apps
 Additionally, you can edit the `blacklist` file in the `~/.config/svim/` folder
 to manually exclude applications from being handled by svim.
 You will likely want to blacklist your terminal emulator and gvim, such that there
 is no conflict.
 
+## Whitelist App
+svim can temporarily whitelist the currently focused app by pressing `OPTION+I`, which will start the vim buffer in insert mode. Only one app can be whitelisted at a time. 
+
+To remove the app from the whitelist, press `OPTION+I` again or set a different app as the whitelisted app.
+
+## svim.sh
 Every time the vim mode changes, or a commandline update is issued, the script
 `svim.sh` in the folder `~/.config/svim/` is executed where you can handle 
 how you want to process this information. I have a small popup in my [SketchyBar](https://github.com/FelixKratz/SketchyBar)
@@ -38,6 +46,17 @@ where you will be asked to grant accessibility permissions.
 You can change the macOS selection color to anything you like with this command (which is my green):
 ```bash
 defaults write NSGlobalDomain AppleHighlightColor -string "0.615686 0.823529 0.454902"
+```
+
+## Development
+To build:
+```
+make
+```
+
+To run:
+```
+./bin/svim
 ```
 
 ## Issues

--- a/src/ax.h
+++ b/src/ax.h
@@ -6,11 +6,16 @@
 #define ROLE_TABLE  1 << 1
 #define ROLE_SCROLL 1 << 2
 
+// Define the modifier flag masks
 #define FLAG_SHIFT   1 << 17
+#define FLAG_CONTROL 1 << 18
+#define FLAG_OPTION  1 << 19
 #define FLAG_COMMAND 1 << 20
 
 #define ENTER  0x0D
 #define ESCAPE 0x1B
+
+#define KEYCODE_I 34
 
 #ifdef GUI_MOVES
 

--- a/src/event_tap.c
+++ b/src/event_tap.c
@@ -22,7 +22,25 @@ static CGEventRef key_handler(CGEventTapProxy proxy, CGEventType type,
       CGEventTapEnable(((struct event_tap*) reference)->handle, true);
     } break;
     case kCGEventKeyDown: {
-      if (((struct event_tap*) reference)->front_app_ignored) {
+      // Get modifier flags
+      CGEventFlags flags = CGEventGetFlags(event);
+      int keycode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+
+      struct event_tap* event_tap_ref = ((struct event_tap*) reference);
+      // Enabled/disable whitelist for app when OPTION+I is pressed.
+      if (keycode == KEYCODE_I && (flags & FLAG_OPTION)){
+          // Switch whitelist app to current app if no whitelist app set or a new app is focused
+          if (event_tap_ref->whitelist_app != event_tap_ref->front_app_name) {
+            event_tap_ref->whitelist_app = event_tap_ref->front_app_name;
+          } else {
+            // Remove whitelist app if key combo pressed while focused on whitelisted app
+            event_tap_ref->whitelist_app = NULL;
+          }
+          // Prevent event keys from being processed by focused app
+          event = CGEventCreate(NULL); 
+      }
+
+      if (event_tap_ref->whitelist_app != event_tap_ref->front_app_name && event_tap_ref->front_app_ignored) {
         if (g_ax.selected_element && g_ax.role) {
           ax_clear(&g_ax);
         }

--- a/src/event_tap.h
+++ b/src/event_tap.h
@@ -10,6 +10,8 @@ extern char* string_copy(char* s);
 
 struct event_tap {
   bool front_app_ignored;
+  char* front_app_name;
+  char* whitelist_app;
   uint32_t blacklist_count;
   char** blacklist;
   CFMachPortRef handle;

--- a/src/workspace.m
+++ b/src/workspace.m
@@ -41,9 +41,8 @@ void workspace_begin(void **context) {
       }
     }
 
-    g_event_tap.front_app_ignored = event_tap_check_blacklist(&g_event_tap,
-                                                              name,
-                                                              bundle_id    );
+    g_event_tap.front_app_name = name;
+    g_event_tap.front_app_ignored = event_tap_check_blacklist(&g_event_tap, name, bundle_id);
     ax_front_app_changed(&g_ax, pid);
 }
 


### PR DESCRIPTION
## Whitelist App
svim can temporarily whitelist the currently focused app by pressing `OPTION+I`, which will start the vim buffer in insert mode. 

To remove the app from the whitelist, press `OPTION+I` again or set a different app as the whitelisted app.
