### PR TITLE
feat: add window watch for application like raycast

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ CFLAGS = $(WARN_FLAGS) $(DEFINES) -g -Ilib -Ilib/libvim/proto -std=c99 -O2 #-fsa
 ODIR = bin
 SRC = src
 
-_OBJ = helpers.om workspace.om event_tap.o ax.o buffer.o line.o env_vars.o
+_OBJ = helpers.om workspace.om event_tap.o ax.o buffer.o line.o env_vars.o window_detector.o
 OBJ = $(patsubst %, $(ODIR)/%, $(_OBJ))
 
 .PHONY: all x86 arm64 universal sign lib clean

--- a/src/ax.c
+++ b/src/ax.c
@@ -1,26 +1,29 @@
 #include "ax.h"
 #include "buffer.h"
 
-void ax_begin(struct ax* ax) {
+void ax_begin(struct ax *ax)
+{
   buffer_begin(&ax->buffer);
   ax->system_element = NULL;
   ax->selected_element = NULL;
   ax->role = 0;
 
-  const void *keys[] = { kAXTrustedCheckOptionPrompt };
-  const void *values[] = { kCFBooleanTrue };
+  const void *keys[] = {kAXTrustedCheckOptionPrompt};
+  const void *values[] = {kCFBooleanTrue};
 
   CFDictionaryRef options;
   options = CFDictionaryCreate(kCFAllocatorDefault,
                                keys, values, sizeof(keys) / sizeof(*keys),
                                &kCFCopyStringDictionaryKeyCallBacks,
-                               &kCFTypeDictionaryValueCallBacks           );
+                               &kCFTypeDictionaryValueCallBacks);
 
   ax->is_privileged = AXIsProcessTrustedWithOptions(options);
   CFRelease(options);
 
-  if (ax->is_privileged) ax->system_element = AXUIElementCreateSystemWide();
-  else {
+  if (ax->is_privileged)
+    ax->system_element = AXUIElementCreateSystemWide();
+  else
+  {
     printf("Accessibility not granted. Exit.");
     exit(1);
   }
@@ -28,55 +31,69 @@ void ax_begin(struct ax* ax) {
   assert(ax->system_element != NULL);
 }
 
-static inline bool ax_get_text(struct ax* ax) {
+static inline bool ax_get_text(struct ax *ax)
+{
   CFTypeRef text_ref = NULL;
   AXError error = AXUIElementCopyAttributeValue(ax->selected_element,
                                                 kAXValueAttribute,
-                                                &text_ref            );
-  if(error == kAXErrorSuccess) {
-    char* raw = cfstring_get_cstring(text_ref);
-    if (!raw) {
+                                                &text_ref);
+  if (error == kAXErrorSuccess)
+  {
+    char *raw = cfstring_get_cstring(text_ref);
+    if (!raw)
+    {
       CFRelease(text_ref);
       return false;
-    } 
+    }
 
-    if (!ax->buffer.raw || !(strcmp(ax->buffer.raw, raw) == 0)) {
-      if (ax->buffer.raw) free(ax->buffer.raw);
+    if (!ax->buffer.raw || !(strcmp(ax->buffer.raw, raw) == 0))
+    {
+      if (ax->buffer.raw)
+        free(ax->buffer.raw);
       ax->buffer.raw = raw;
       buffer_revsync_text(&ax->buffer);
     }
-    else free(raw);
+    else
+      free(raw);
   }
 
-  if (text_ref) CFRelease(text_ref);
+  if (text_ref)
+    CFRelease(text_ref);
   return error == kAXErrorSuccess;
 }
 
-static inline bool ax_get_cursor(struct ax* ax) {
+static inline bool ax_get_cursor(struct ax *ax)
+{
   CFTypeRef text_range_ref = NULL;
   CFRange text_range = CFRangeMake(0, 0);
   AXError error = AXUIElementCopyAttributeValue(ax->selected_element,
                                                 kAXSelectedTextRangeAttribute,
-                                                &text_range_ref              );
+                                                &text_range_ref);
 
-  if (error == kAXErrorSuccess) {
+  if (error == kAXErrorSuccess)
+  {
     AXValueGetValue(text_range_ref, kAXValueCFRangeType, &text_range);
 
-    if (ax->buffer.cursor.position  != text_range.location || 
-        ax->buffer.cursor.selection != text_range.length     ) {
+    if (ax->buffer.cursor.position != text_range.location ||
+        ax->buffer.cursor.selection != text_range.length)
+    {
       ax->buffer.cursor.position = text_range.location;
       ax->buffer.cursor.selection = text_range.length;
       buffer_revsync_cursor(&ax->buffer);
     }
   }
 
-  if (text_range_ref) CFRelease(text_range_ref);
+  if (text_range_ref)
+    CFRelease(text_range_ref);
   return error == kAXErrorSuccess;
 }
 
-static inline bool ax_set_text(struct ax* ax) {
-  if (!ax->is_supported || !ax->buffer.raw) return false;
-  if (!ax->buffer.did_change) return true;
+static inline bool ax_set_text(struct ax *ax)
+{
+  if (!ax->is_supported || !ax->buffer.raw)
+    return false;
+  if (!ax->buffer.did_change)
+    return true;
 
   CFStringRef text_ref = CFStringCreateWithCString(NULL,
                                                    ax->buffer.raw,
@@ -84,44 +101,47 @@ static inline bool ax_set_text(struct ax* ax) {
 
   AXError error = AXUIElementSetAttributeValue(ax->selected_element,
                                                kAXValueAttribute,
-                                               text_ref             );
+                                               text_ref);
 
   CFRelease(text_ref);
   return error == kAXErrorSuccess;
 }
 
-static inline bool ax_set_cursor(struct ax* ax) {
-  if (!ax->is_supported) return false;
+static inline bool ax_set_cursor(struct ax *ax)
+{
+  if (!ax->is_supported)
+    return false;
 
   CFRange text_range = CFRangeMake(ax->buffer.cursor.position,
                                    ax->buffer.cursor.selection);
   AXValueRef value = AXValueCreate(kAXValueCFRangeType, &text_range);
   // HACK: This is needed when the text has been set to give the
   // HACK: AX API some time to breathe...
-  if (ax->buffer.did_change) usleep(15000);
+  if (ax->buffer.did_change)
+    usleep(15000);
 
   AXError error = AXUIElementSetAttributeValue(ax->selected_element,
                                                kAXSelectedTextRangeAttribute,
-                                               value                         );
+                                               value);
 
   CFRelease(value);
   return error == kAXErrorSuccess;
 }
 
-static inline bool ax_set_buffer(struct ax* ax) {
-  return ax_set_text(ax)
-      && ax_set_cursor(ax);
+static inline bool ax_set_buffer(struct ax *ax)
+{
+  return ax_set_text(ax) && ax_set_cursor(ax);
 }
 
-static inline bool ax_get_selected_element(struct ax* ax) {
+static inline bool ax_get_selected_element(struct ax *ax)
+{
   CFTypeRef selected_element = NULL;
   AXError error = AXUIElementCopyAttributeValue(ax->system_element,
                                                 kAXFocusedUIElementAttribute,
-                                                &selected_element            );
+                                                &selected_element);
 
-  if (ax->selected_element && selected_element
-                           && CFEqual(ax->selected_element,
-                                      selected_element     )) {
+  if (ax->selected_element && selected_element && CFEqual(ax->selected_element, selected_element))
+  {
     CFRelease(selected_element);
     return true;
   }
@@ -130,33 +150,40 @@ static inline bool ax_get_selected_element(struct ax* ax) {
   uint32_t role = 0;
   CFTypeRef role_ref = NULL;
 
-  if (selected_element) {
+  if (selected_element)
+  {
     AXUIElementCopyAttributeValue(selected_element,
                                   kAXRoleAttribute,
-                                  &role_ref        );
+                                  &role_ref);
 
     if (role_ref && (CFEqual(role_ref, kAXTextFieldRole) ||
-                     CFEqual(role_ref,  kAXTextAreaRole) ||
-                     CFEqual(role_ref,  kAXComboBoxRole)   )) {
+                     CFEqual(role_ref, kAXTextAreaRole) ||
+                     CFEqual(role_ref, kAXComboBoxRole)))
+    {
       role = ROLE_TEXT;
     }
-    else if (role_ref && (CFEqual(role_ref,   kAXTableRole) ||
-                          CFEqual(role_ref,  kAXButtonRole) ||
-                          CFEqual(role_ref, kAXOutlineRole)   )) {
+    else if (role_ref && (CFEqual(role_ref, kAXTableRole) ||
+                          CFEqual(role_ref, kAXButtonRole) ||
+                          CFEqual(role_ref, kAXOutlineRole)))
+    {
       role = ROLE_TABLE;
     }
-    else if (role_ref && CFEqual(role_ref, kAXGroupRole)) {
+    else if (role_ref && CFEqual(role_ref, kAXGroupRole))
+    {
       role = ROLE_SCROLL;
     }
-    else if (role_ref) {
+    else if (role_ref)
+    {
       // char* role = cfstring_get_cstring(role_ref);
       // printf("Role: %s\n", role);
       // free(role);
     }
 
-    if (role_ref) CFRelease(role_ref);
+    if (role_ref)
+      CFRelease(role_ref);
 
-    if (!role) {
+    if (!role)
+    {
       CFRelease(selected_element);
       selected_element = NULL;
     }
@@ -168,31 +195,37 @@ static inline bool ax_get_selected_element(struct ax* ax) {
   return (error == kAXErrorSuccess) && role;
 }
 
-bool ax_process_selected_element(struct ax* ax) {
-  ax->is_supported = ax_get_selected_element(ax); 
+bool ax_process_selected_element(struct ax *ax)
+{
+  ax->is_supported = ax_get_selected_element(ax);
 
   bool success = true;
-  if (ax->role == ROLE_TEXT && ax->buffer.cursor.mode != INSERT) {
+  if (ax->role == ROLE_TEXT && ax->buffer.cursor.mode != INSERT)
+  {
     success = ax_get_text(ax) && ax_get_cursor(ax);
   }
 
   return ax->is_supported && success;
 }
 
-void ax_front_app_changed(struct ax* ax, pid_t pid) {
+void ax_front_app_changed(struct ax *ax, pid_t pid)
+{
 #ifdef MANUAL_AX
   AXUIElementRef app = AXUIElementCreateApplication(pid);
-  if (app) {
+  if (app)
+  {
     AXUIElementSetAttributeValue(app,
                                  CFSTR("AXManualAccessibility"),
-                                 kCFBooleanTrue                 );
+                                 kCFBooleanTrue);
     CFRelease(app);
   }
 #endif
 }
 
-CGEventRef ax_process_event(struct ax* ax, CGEventRef event) {
-  if (!ax_process_selected_element(ax)) return event;
+CGEventRef ax_process_event(struct ax *ax, CGEventRef event)
+{
+  if (!ax_process_selected_element(ax))
+    return event;
 
   UniCharCount count;
   UniChar character;
@@ -205,7 +238,7 @@ CGEventRef ax_process_event(struct ax* ax, CGEventRef event) {
   // Command
   if (flags & FLAG_COMMAND)
     return event;
-  
+
   // Shift Enter
   if (character == ENTER && (flags & FLAG_SHIFT))
     return event;
@@ -214,7 +247,8 @@ CGEventRef ax_process_event(struct ax* ax, CGEventRef event) {
   if (character == ESCAPE && (flags & FLAG_SHIFT))
     return event;
 
-  if (ax->role == ROLE_TEXT) {
+  if (ax->role == ROLE_TEXT)
+  {
     // Escape in normal mode
     if (character == ESCAPE && ax->buffer.cursor.mode & NORMAL)
       return event;
@@ -222,15 +256,17 @@ CGEventRef ax_process_event(struct ax* ax, CGEventRef event) {
     // Enter in normal mode
     if (character == ENTER && ax->buffer.cursor.mode & NORMAL)
       return event;
-    
-    bool was_insert = ax->buffer.cursor.mode & INSERT
-                      || !ax->buffer.cursor.mode;
+
+    bool was_insert = ax->buffer.cursor.mode & INSERT || !ax->buffer.cursor.mode;
     buffer_input(&ax->buffer, character, count);
 
     // Insert mode is passed and only synced later
-    if (was_insert && ax->buffer.cursor.mode & INSERT) return event;
-    else if (was_insert) {
-      if (!ax_get_text(ax) || !ax_get_cursor(ax)) return event;
+    if (was_insert && ax->buffer.cursor.mode & INSERT)
+      return event;
+    else if (was_insert)
+    {
+      if (!ax_get_text(ax) || !ax_get_cursor(ax))
+        return event;
     }
 
     ax_set_buffer(ax);
@@ -241,39 +277,62 @@ CGEventRef ax_process_event(struct ax* ax, CGEventRef event) {
 #ifdef GUI_MOVES
   // NOTE: Gui movement is currently hardcoded for my movement keys jklö and
   // NOTE: only available when compiling with the -DGUI_MOVES flag
-  if (ax->role == ROLE_TABLE || ax->role == ROLE_SCROLL) {
-    switch (character) {
-      case K: {
-        CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
-        CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 125);
-      } break;
-      case L: {
-        CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
-        CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 126);
-      } break;
-      case J: {
-        CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
-        CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 123);
-      } break;
-      case OE: {
-        CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
-        CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 124);
-      } break;
+  if (ax->role == ROLE_TABLE || ax->role == ROLE_SCROLL)
+  {
+    switch (character)
+    {
+    case K:
+    {
+      CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 125);
+    }
+    break;
+    case L:
+    {
+      CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 126);
+    }
+    break;
+    case J:
+    {
+      CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 123);
+    }
+    break;
+    case OE:
+    {
+      CGEventSetIntegerValueField(event, kCGKeyboardEventAutorepeat, false);
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, 124);
+    }
+    break;
     }
   }
-#endif //GUI_MOVES
+#endif // GUI_MOVES
 
   return event;
 }
 
-void ax_clear(struct ax* ax) {
+void ax_clear(struct ax *ax)
+{
   buffer_clear(&ax->buffer);
-  if (ax->selected_element && ax->role == ROLE_TEXT) {
+  if (ax->selected_element && ax->role == ROLE_TEXT)
+  {
     buffer_call_script(&ax->buffer, false);
   }
 
-  if (ax->selected_element) CFRelease(ax->selected_element);
+  if (ax->selected_element)
+    CFRelease(ax->selected_element);
   ax->role = 0;
   ax->selected_element = NULL;
   ax->is_supported = false;
+}
+
+void ax_end(struct ax *ax)
+{
+  ax_clear(ax);
+  if (ax->system_element)
+  {
+    CFRelease(ax->system_element);
+    ax->system_element = NULL;
+  }
 }

--- a/src/ax.h
+++ b/src/ax.h
@@ -2,28 +2,29 @@
 #include <Carbon/Carbon.h>
 #include "buffer.h"
 
-#define ROLE_TEXT   1
-#define ROLE_TABLE  1 << 1
+#define ROLE_TEXT 1
+#define ROLE_TABLE 1 << 1
 #define ROLE_SCROLL 1 << 2
 
-#define FLAG_SHIFT   1 << 17
+#define FLAG_SHIFT 1 << 17
 #define FLAG_COMMAND 1 << 20
 
-#define ENTER  0x0D
+#define ENTER 0x0D
 #define ESCAPE 0x1B
 
 #ifdef GUI_MOVES
 
-#define J  0x6A
-#define K  0x6B
-#define L  0x6C
+#define J 0x6A
+#define K 0x6B
+#define L 0x6C
 #define OE 0xF6
 
-#endif //GUI_MOVES
+#endif // GUI_MOVES
 
-extern char* cfstring_get_cstring(CFStringRef text_ref);
+extern char *cfstring_get_cstring(CFStringRef text_ref);
 
-struct ax {
+struct ax
+{
   bool is_privileged;
   bool is_supported;
 
@@ -35,8 +36,9 @@ struct ax {
 };
 
 struct ax g_ax;
-void ax_begin(struct ax* ax);
-void ax_clear(struct ax* ax);
+void ax_begin(struct ax *ax);
+void ax_end(struct ax *ax);
+void ax_clear(struct ax *ax);
 
-CGEventRef ax_process_event(struct ax* ax, CGEventRef event);
-void ax_front_app_changed(struct ax* ax, pid_t pid);
+CGEventRef ax_process_event(struct ax *ax, CGEventRef event);
+void ax_front_app_changed(struct ax *ax, pid_t pid);

--- a/src/main.m
+++ b/src/main.m
@@ -3,8 +3,20 @@
 #include "event_tap.h"
 #include "ax.h"
 #include "workspace.h"
+#include <signal.h>
 
 void* g_workspace;
+
+static void cleanup_and_exit(int sig) {
+    (void)sig; // Unused parameter
+    printf("\nShutting down...\n");
+    
+    event_tap_end(&g_event_tap);
+    ax_end(&g_ax);
+    workspace_end(&g_workspace);
+    
+    exit(0);
+}
 
 static void acquire_lockfile(void) {
   char *user = getenv("USER");
@@ -37,6 +49,8 @@ int main (int argc, char *argv[]) {
   NSApplicationLoad();
   signal(SIGCHLD, SIG_IGN);
   signal(SIGPIPE, SIG_IGN);
+  signal(SIGINT, cleanup_and_exit);
+  signal(SIGTERM, cleanup_and_exit);
 
   acquire_lockfile();
   ax_begin(&g_ax);

--- a/src/window_detector.c
+++ b/src/window_detector.c
@@ -1,0 +1,179 @@
+#include "window_detector.h"
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Forward declaration of helper function
+extern char *cfstring_get_cstring(CFStringRef text_ref);
+extern char *string_copy(char *s);
+
+static pthread_t detector_thread;
+static bool detector_running = false;
+static window_detector_callback user_callback = NULL;
+static char **watched_apps = NULL;
+static int watched_apps_count = 0;
+static bool *last_visibility_states = NULL;
+
+// Check if a specific application has any visible windows
+bool window_detector_is_app_visible(const char *app_name)
+{
+    CFArrayRef window_list = CGWindowListCopyWindowInfo(
+        kCGWindowListOptionOnScreenOnly,
+        kCGNullWindowID);
+
+    if (!window_list)
+    {
+        return false;
+    }
+
+    CFIndex window_count = CFArrayGetCount(window_list);
+    bool found = false;
+
+    for (CFIndex i = 0; i < window_count; i++)
+    {
+        CFDictionaryRef window_info = (CFDictionaryRef)CFArrayGetValueAtIndex(window_list, i);
+        if (!window_info)
+            continue;
+
+        CFStringRef owner_name = (CFStringRef)CFDictionaryGetValue(window_info, kCGWindowOwnerName);
+        if (owner_name)
+        {
+            char *owner_cstring = cfstring_get_cstring(owner_name);
+            if (owner_cstring && strcmp(owner_cstring, app_name) == 0)
+            {
+                found = true;
+                free(owner_cstring);
+                break;
+            }
+            if (owner_cstring)
+                free(owner_cstring);
+        }
+    }
+
+    CFRelease(window_list);
+    return found;
+}
+
+// Load watched apps from blacklist
+static void load_watched_apps(void)
+{
+    char *home = getenv("HOME");
+    char buf[512];
+    snprintf(buf, sizeof(buf), "%s/%s", home, ".config/svim/blacklist");
+
+    FILE *file = fopen(buf, "r");
+    if (!file)
+        return;
+
+    char line[255];
+    while (fgets(line, 255, file))
+    {
+        uint32_t len = strlen(line);
+        if (line[len - 1] == '\n')
+            line[len - 1] = '\0';
+
+        // Skip empty lines
+        if (len <= 1)
+            continue;
+
+        watched_apps = realloc(watched_apps, sizeof(char *) * (watched_apps_count + 1));
+        last_visibility_states = realloc(last_visibility_states, sizeof(bool) * (watched_apps_count + 1));
+
+        watched_apps[watched_apps_count] = string_copy(line);
+        last_visibility_states[watched_apps_count] = false;
+        watched_apps_count++;
+    }
+    fclose(file);
+}
+
+// Polling thread function
+static void *detector_thread_func(void *arg)
+{
+    (void)arg; // Unused parameter
+
+    while (detector_running)
+    {
+        for (int i = 0; i < watched_apps_count; i++)
+        {
+            bool current_visible = window_detector_is_app_visible(watched_apps[i]);
+
+            // Check for state change
+            if (current_visible != last_visibility_states[i])
+            {
+                if (user_callback)
+                {
+                    user_callback(watched_apps[i], current_visible);
+                }
+                last_visibility_states[i] = current_visible;
+            }
+        }
+
+        // Sleep for 0.5 seconds
+        usleep(500000); // 500ms = 0.5s
+    }
+
+    return NULL;
+}
+
+void window_detector_set_callback(window_detector_callback callback)
+{
+    user_callback = callback;
+}
+
+void window_detector_begin(void)
+{
+    if (detector_running)
+        return;
+
+    load_watched_apps();
+
+    if (watched_apps_count == 0)
+    {
+        return; // No apps to watch
+    }
+
+    detector_running = true;
+
+    if (pthread_create(&detector_thread, NULL, detector_thread_func, NULL) != 0)
+    {
+        detector_running = false;
+        return;
+    }
+}
+
+void window_detector_end(void)
+{
+    if (!detector_running)
+        return;
+
+    detector_running = false;
+    pthread_join(detector_thread, NULL);
+
+    // Clean up
+    for (int i = 0; i < watched_apps_count; i++)
+    {
+        if (watched_apps[i])
+        {
+            free(watched_apps[i]);
+        }
+    }
+
+    if (watched_apps)
+    {
+        free(watched_apps);
+        watched_apps = NULL;
+    }
+
+    if (last_visibility_states)
+    {
+        free(last_visibility_states);
+        last_visibility_states = NULL;
+    }
+
+    watched_apps_count = 0;
+    user_callback = NULL;
+}

--- a/src/window_detector.h
+++ b/src/window_detector.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stdbool.h>
+#include <CoreGraphics/CoreGraphics.h>
+
+// Function to check if a specific application has any visible windows
+bool window_detector_is_app_visible(const char *app_name);
+
+// Function to start the window detection polling
+void window_detector_begin(void);
+
+// Function to stop the window detection polling
+void window_detector_end(void);
+
+// Callback function type for when app visibility changes
+typedef void (*window_detector_callback)(const char *app_name, bool is_visible);
+
+// Set the callback function
+void window_detector_set_callback(window_detector_callback callback);

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -1,14 +1,17 @@
 #pragma once
 #include <Cocoa/Cocoa.h>
 #include "event_tap.h"
+#include "window_detector.h"
 
 bool g_front_app_ignored;
 
-extern char* string_copy(char* s);
+extern char *string_copy(char *s);
 
-@interface workspace_context : NSObject {
+@interface workspace_context : NSObject
+{
 }
 - (id)init;
 @end
 
 void workspace_begin(void **context);
+void workspace_end(void **context);


### PR DESCRIPTION
Thank you for creating and maintaining svim! 
I use it daily and really appreciate all your hard work

What’s the problem?
When open Raycast and also having Raycast in the blacklist file, svim doesn’t respect it and keep showing the vim buffer inside Raycast. 
(I guess it Because Raycast never sends a “window changed” notification).

What’s changed?
This PR adds special handling for Raycast (and application like that) so that any blacklisted buffers remain disabled even if Raycast doesn’t emit the usual visibility event.

Feel free to ignore this PR if you’d rather not include it, but it fixes the Raycast issue I was running into. Thanks again for your awesome work!